### PR TITLE
Add nodemon to dev dependencies (fixes #14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lodash": "^2.4.1",
     "lru-cache": "^2.5.0",
     "morgan": "^1.3.2",
+    "nodemon": "^1.3.7",
     "rsvp": "^3.0.14",
     "serve-favicon": "^2.1.5",
     "stripcolorcodes": "^0.1.0",


### PR DESCRIPTION
Nodemon should have been in the dependencies list, so that the `npm start` command will work without having nodemon globally-installed. Props to @snhasani for finding the issue!
